### PR TITLE
Adding Docker build + publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+---
+name: 'CI'
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - v*
+    pull_request:
+      branches:
+        - '*'
+env:
+  IMAGE_NAME: 'fhdhr_locast'
+jobs:
+  build_test_push_docker_image:
+    name: 'build-push'
+    needs:
+      - 'hadolint'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'checkout'
+        uses: 'actions/checkout@v2'
+      - name: 'build and tag image'
+        id: 'build-tag-image'
+        run: |
+          docker build --file Dockerfile --tag ${IMAGE_NAME} .
+      - name: Log into registry
+        run: echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: 'push image'
+        if: "${{ github.ref == 'refs/heads/main' }}"
+        id: 'push-image'
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.actor }}/$IMAGE_NAME
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "main" ] && VERSION=latest
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION
+  hadolint:
+    name: 'hadolint'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'actions/checkout@v2'
+      - uses: 'burdzwastaken/hadolint-action@master'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.8-slim
-  
+FROM python:3.9-slim
+
 RUN apt-get -qq update && \
-    apt-get -qq -y install ffmpeg gcc && \
+    apt-get -qq -y install --no-install-recommends ffmpeg=7:4.1.6* gcc=4:8.3.0* && \
     apt-get autoclean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Move to py 3.9 in Docker and pin the FFMPEG version to conform to hadolint standards. This PR will also start building Docker images using GitHub actions and publishes to GitHub using GitHub ContainerRegistry, just fyi. If you create a DockerHub account and prefer to push them there instead, the GitHub actions code would need to be modified or removed in favor of building somewhere else. This won't work out of the box, you'll need to enable Container Registry and then create a Personal Access Token with `package:write` permissions. Then in this project create a secret called CR_PAT with the value being the Personal Access Token you created. This will allow GitHub Actions to push the built container image to the Container Registry (https://github.blog/2020-09-01-introducing-github-container-registry/)

I'd be interested in digging in further to the code to adjust/allow some configuration values to be specified as ENV vars as well since that is Docker convention, but it sounds like there is some changes coming to the config handling in general that might be worth waiting on.

I kept FFMPEG in there since it looks like it's still an option if folks chose to use it, this way the image wouldn't need to be rebuilt or modified to support that use case.